### PR TITLE
Add Brownian motion and faster boiling

### DIFF
--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -209,10 +209,13 @@ function getIceHeightPx(){
 function getIceTopPx(){
     const h = getIceHeightPx();
     const waterHeight = getWaterHeightPx();
-    if(waterHeight > h*2/3){
-        return beakerBottom - waterHeight - h/3;
+    // keep the ice resting on the bottom until most of it is submerged
+    if(waterHeight <= h*2/3){
+        return beakerBottom - h;
     }
-    return beakerBottom - waterHeight - h;
+    // once water covers more than two thirds of the ice height,
+    // let the block float with one third above the waterline
+    return beakerBottom - waterHeight - h/3;
 }
 function getWaterHeightPx(){
     const V = state.massWater / RHO_WATER;

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -124,6 +124,8 @@ const ICE_COLS = 20;
 const ICE_ROWS = 20; // row 0 at bottom
 let ICE_WIDTH0 = 0;  // px, set during resize
 let ICE_HEIGHT0 = 0; // px, set during resize
+let C_SPACING0 = 0;  // base column spacing
+let R_SPACING0 = 0;  // base row spacing
 
 let canvas = document.getElementById('mainCanvas');
 let gCanvas = document.getElementById('graphCanvas');
@@ -178,6 +180,8 @@ function resize() {
     const w0m = ICE_WIDTH0/pxPerM;
     const V0 = MASS_ICE_INIT / RHO_ICE;
     ICE_HEIGHT0 = (V0/(w0m*w0m))*pxPerM;
+    C_SPACING0 = (ICE_WIDTH0 - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
+    R_SPACING0 = (ICE_HEIGHT0 - 2*PARTICLE_RADIUS)/(ICE_ROWS - 1);
 }
 
 function createParticles() {
@@ -186,8 +190,8 @@ function createParticles() {
     const iceHeight = getIceHeightPx();
     const startX = (canvas.width - iceWidth)/2;
     const bottomY = getIceTopPx() + iceHeight;
-    const cSpacing = (iceWidth - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
-    const rSpacing = (iceHeight - 2*PARTICLE_RADIUS)/(ICE_ROWS - 1);
+    const cSpacing = C_SPACING0 * getIceScale();
+    const rSpacing = R_SPACING0 * getIceScale();
     for(let r=0;r<ICE_ROWS;r++){
         for(let c=0;c<ICE_COLS;c++){
             const x = startX + PARTICLE_RADIUS + c*cSpacing + (r%2?cSpacing/2:0);
@@ -274,32 +278,37 @@ function updatePhysics(dt){
 function updateParticles(dt){
     frameCount++;
     const impulse = (frameCount % 10 === 0);
+    const scale = getIceScale();
     const waterHeight = getWaterHeightPx();
-    const iceHeight = getIceHeightPx();
-    const iceWidth = getIceWidthPx();
+    const iceHeight = ICE_HEIGHT0 * scale;
+    const iceWidth = ICE_WIDTH0 * scale;
     const iceLeft = (canvas.width - iceWidth)/2;
     const iceTop = getIceTopPx();
-    const startX = iceLeft;
     const iceBottom = iceTop + iceHeight;
-    const cSpacing = (iceWidth - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
+    const cSpacing = C_SPACING0 * scale;
+    const rSpacing = R_SPACING0 * scale;
+
     let solidCount = Math.round(state.massIce/MASS_ICE_INIT*PARTICLE_COUNT);
-    solidCount = Math.min(solidCount, PARTICLE_COUNT);
-    const solidRows = solidCount > 0 ? Math.ceil(solidCount/ICE_COLS) : 0;
-    const rSpacing = solidRows>1 ?
-        (iceHeight - 2*PARTICLE_RADIUS)/(solidRows-1) : 0;
+    solidCount = Math.max(0, Math.min(solidCount, PARTICLE_COUNT));
     let waterCount = Math.round(state.massWater/MASS_ICE_INIT*PARTICLE_COUNT);
+    waterCount = Math.max(0, Math.min(waterCount, PARTICLE_COUNT - solidCount));
+    const gasCount = PARTICLE_COUNT - solidCount - waterCount;
+    const meltCount = gasCount + waterCount;
+
     for(let i=0;i<PARTICLE_COUNT;i++){
         const p = particles[i];
-        if(i<solidCount){
+        if(i >= meltCount){
+            // solid lattice (top portion)
             p.phase='solid';
             const vibAmp=Math.max(0,Math.min(2,(state.temperature+10)*0.2));
-            const row = Math.floor(i/ICE_COLS);
-            const col = i%ICE_COLS;
-            p.baseX = startX + PARTICLE_RADIUS + col*cSpacing + (row%2?cSpacing/2:0);
+            const j=i-meltCount;
+            const row=Math.floor(j/ICE_COLS);
+            const col=j%ICE_COLS;
+            p.baseX = iceLeft + PARTICLE_RADIUS + col*cSpacing + (row%2?cSpacing/2:0);
             p.baseY = iceBottom - PARTICLE_RADIUS - row*rSpacing;
             p.x=p.baseX+vibAmp*Math.sin(Date.now()/200+p.baseX);
             p.y=p.baseY+vibAmp*Math.sin(Date.now()/200+p.baseY);
-        }else if(i<solidCount+waterCount){
+        }else if(i >= gasCount){
             if(p.phase!=='liquid'){
                 p.x=beakerLeft+Math.random()*beakerWidth;
                 p.y=beakerBottom-waterHeight*Math.random();

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -281,11 +281,25 @@ function updateParticles(dt){
                 p.vx += (Math.random() - 0.5) * BROWNIAN_LIQ_IMPULSE;
                 p.vy += (Math.random() - 0.5) * BROWNIAN_LIQ_IMPULSE;
             }
-            p.x+=p.vx*dt*tempFactor;
-            p.y+=p.vy*dt*tempFactor;
-            if(p.x<beakerLeft+PARTICLE_RADIUS||p.x>beakerLeft+beakerWidth-PARTICLE_RADIUS)p.vx*=-1;
-            if(p.y>beakerBottom-PARTICLE_RADIUS){p.vy*=-1;p.y=beakerBottom-PARTICLE_RADIUS;}
-            if(p.y<beakerBottom-waterHeight+PARTICLE_RADIUS){p.vy*=-1;p.y=beakerBottom-waterHeight+PARTICLE_RADIUS;}
+            p.x += p.vx * dt * tempFactor;
+            p.y += p.vy * dt * tempFactor;
+            if(p.x < beakerLeft + PARTICLE_RADIUS){
+                p.x = beakerLeft + PARTICLE_RADIUS;
+                p.vx = Math.abs(p.vx);
+            }
+            if(p.x > beakerLeft + beakerWidth - PARTICLE_RADIUS){
+                p.x = beakerLeft + beakerWidth - PARTICLE_RADIUS;
+                p.vx = -Math.abs(p.vx);
+            }
+            if(p.y > beakerBottom - PARTICLE_RADIUS){
+                p.y = beakerBottom - PARTICLE_RADIUS;
+                p.vy = -Math.abs(p.vy);
+            }
+            const top = beakerBottom - waterHeight + PARTICLE_RADIUS;
+            if(p.y < top){
+                p.y = top;
+                p.vy = Math.abs(p.vy);
+            }
             let evapChance=0.02*Math.exp(state.temperature/50)*dt;
             if(state.temperature>=100) evapChance*=2; // faster release when boiling
             if(p.y<beakerBottom-waterHeight+2*PARTICLE_RADIUS && Math.random()<evapChance){
@@ -312,10 +326,21 @@ function updateParticles(dt){
                 p.vx += (Math.random() - 0.5) * BROWNIAN_GAS_IMPULSE;
                 p.vy += (Math.random() - 0.5) * BROWNIAN_GAS_IMPULSE;
             }
-            p.x+=p.vx*dt;
-            p.y+=p.vy*dt;
-            if(p.x<beakerLeft+PARTICLE_RADIUS||p.x>beakerLeft+beakerWidth-PARTICLE_RADIUS)p.vx*=-1;
-            if(p.y<0){p.y=-1000;} // disappear
+            p.x += p.vx * dt;
+            p.y += p.vy * dt;
+            if(p.x < beakerLeft + PARTICLE_RADIUS){
+                p.x = beakerLeft + PARTICLE_RADIUS;
+                p.vx = Math.abs(p.vx);
+            }
+            if(p.x > beakerLeft + beakerWidth - PARTICLE_RADIUS){
+                p.x = beakerLeft + beakerWidth - PARTICLE_RADIUS;
+                p.vx = -Math.abs(p.vx);
+            }
+            if(p.y > beakerBottom - PARTICLE_RADIUS){
+                p.y = beakerBottom - PARTICLE_RADIUS;
+                p.vy = -Math.abs(p.vy);
+            }
+            if(p.y < 0){p.y=-1000;} // disappear
         }
     }
     // simple pairwise collisions for gas particles

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -282,17 +282,21 @@ function updateParticles(dt){
     const startX = iceLeft;
     const iceBottom = iceTop + iceHeight;
     const cSpacing = (iceWidth - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
-    const rSpacing = (iceHeight - 2*PARTICLE_RADIUS)/(ICE_ROWS - 1);
     let solidCount = Math.round(state.massIce/MASS_ICE_INIT*PARTICLE_COUNT);
     solidCount = Math.min(solidCount, PARTICLE_COUNT);
+    const solidRows = solidCount > 0 ? Math.ceil(solidCount/ICE_COLS) : 0;
+    const rSpacing = solidRows>1 ?
+        (iceHeight - 2*PARTICLE_RADIUS)/(solidRows-1) : 0;
     let waterCount = Math.round(state.massWater/MASS_ICE_INIT*PARTICLE_COUNT);
     for(let i=0;i<PARTICLE_COUNT;i++){
         const p = particles[i];
         if(i<solidCount){
             p.phase='solid';
             const vibAmp=Math.max(0,Math.min(2,(state.temperature+10)*0.2));
-            p.baseX = startX + PARTICLE_RADIUS + p.col*cSpacing + (p.row%2?cSpacing/2:0);
-            p.baseY = iceBottom - PARTICLE_RADIUS - p.row*rSpacing;
+            const row = Math.floor(i/ICE_COLS);
+            const col = i%ICE_COLS;
+            p.baseX = startX + PARTICLE_RADIUS + col*cSpacing + (row%2?cSpacing/2:0);
+            p.baseY = iceBottom - PARTICLE_RADIUS - row*rSpacing;
             p.x=p.baseX+vibAmp*Math.sin(Date.now()/200+p.baseX);
             p.y=p.baseY+vibAmp*Math.sin(Date.now()/200+p.baseY);
         }else if(i<solidCount+waterCount){

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -263,49 +263,57 @@ function getWaterHeightPx(){
 
 function updatePhysics(dt){
     state.energy += state.power * dt;
-    switch(state.phase){
-        case 'solid':
-            if(state.temperature < 0){
-                const needed = state.massIce*C_ICE*(0-state.temperature);
-                if(state.energy >= needed){
-                    state.energy -= needed;
-                    state.temperature = 0;
-                }else{
-                    state.temperature += state.energy/(state.massIce*C_ICE);
-                    state.energy = 0;
-                }
-            }else{
-                // melting
-                const meltNeeded = state.massIce*L_FUS;
-                const dm = Math.min(state.energy/L_FUS,state.massIce);
+    const EPS = 1e-9;
+    while(state.energy > EPS){
+        if(state.phase === 'solid' && state.temperature < 0){
+            const needed = state.massIce * C_ICE * (0 - state.temperature);
+            if(state.energy < needed){
+                state.temperature += state.energy / (state.massIce * C_ICE);
+                state.energy = 0;
+                break;
+            }
+            state.energy -= needed;
+            state.temperature = 0;
+        } else if(state.phase === 'solid'){
+            const needed = state.massIce * L_FUS;
+            if(state.energy < needed){
+                const dm = state.energy / L_FUS;
                 state.massIce -= dm;
                 state.massWater += dm;
-                state.energy -= dm*L_FUS;
-                if(state.massIce===0){state.phase='liquid';}
+                state.energy = 0;
+                break;
             }
-            break;
-        case 'liquid':
-            if(state.temperature < 100){
-                const needed = state.massWater*C_WATER*(100-state.temperature);
-                if(state.energy >= needed){
-                    state.energy -= needed;
-                    state.temperature = 100;
-                }else{
-                    state.temperature += state.energy/(state.massWater*C_WATER);
-                    state.energy = 0;
-                }
-            }else{
-                const dm = Math.min(state.energy/L_VAP,state.massWater);
+            state.massWater += state.massIce;
+            state.energy -= needed;
+            state.massIce = 0;
+            state.phase = 'liquid';
+        } else if(state.phase === 'liquid' && state.temperature < 100){
+            const needed = state.massWater * C_WATER * (100 - state.temperature);
+            if(state.energy < needed){
+                state.temperature += state.energy / (state.massWater * C_WATER);
+                state.energy = 0;
+                break;
+            }
+            state.energy -= needed;
+            state.temperature = 100;
+        } else if(state.phase === 'liquid'){
+            const needed = state.massWater * L_VAP;
+            if(state.energy < needed){
+                const dm = state.energy / L_VAP;
                 state.massWater -= dm;
                 state.massSteam += dm;
-                state.energy -= dm*L_VAP;
-                if(state.massWater===0){state.phase='gas';}
+                state.energy = 0;
+                break;
             }
-            break;
-        case 'gas':
-            state.temperature += state.energy/(state.massSteam*C_WATER);
+            state.massSteam += state.massWater;
+            state.energy -= needed;
+            state.massWater = 0;
+            state.phase = 'gas';
+        } else {
+            // heating steam
+            state.temperature += state.energy / (state.massSteam * C_WATER);
             state.energy = 0;
-            break;
+        }
     }
 }
 

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -188,15 +188,15 @@ function createParticles() {
     particles = [];
     const iceWidth = getIceWidthPx();
     const iceHeight = getIceHeightPx();
-    const startX = (canvas.width - iceWidth)/2;
-    const bottomY = getIceTopPx() + iceHeight;
-    const cSpacing = C_SPACING0 * getIceScale();
-    const rSpacing = R_SPACING0 * getIceScale();
-    for(let r=0;r<ICE_ROWS;r++){
-        for(let c=0;c<ICE_COLS;c++){
-            const x = startX + PARTICLE_RADIUS + c*cSpacing + (r%2?cSpacing/2:0);
-            const y = bottomY - PARTICLE_RADIUS - r*rSpacing;
-            particles.push({row:r,col:c,x,y,vx:0,vy:0,phase:'solid'});
+    const startX = (canvas.width - iceWidth) / 2;
+    const iceTop = getIceTopPx();
+    const cSpacing = (iceWidth - 2 * PARTICLE_RADIUS) / (ICE_COLS - 1);
+    const rSpacing = (iceHeight - 2 * PARTICLE_RADIUS) / (ICE_ROWS - 1);
+    for (let r = 0; r < ICE_ROWS; r++) {
+        for (let c = 0; c < ICE_COLS; c++) {
+            const x = startX + PARTICLE_RADIUS + c * cSpacing + (r % 2 ? cSpacing / 2 : 0);
+            const y = iceTop + PARTICLE_RADIUS + r * rSpacing;
+            particles.push({ row: r, col: c, x, y, vx: 0, vy: 0, phase: 'solid' });
         }
     }
 }
@@ -285,29 +285,31 @@ function updateParticles(dt){
     const iceLeft = (canvas.width - iceWidth)/2;
     const iceTop = getIceTopPx();
     const iceBottom = iceTop + iceHeight;
-    const cSpacing = C_SPACING0 * scale;
-    const rSpacing = R_SPACING0 * scale;
+    const solidCount = Math.round(state.massIce / MASS_ICE_INIT * PARTICLE_COUNT);
+    const waterCount = Math.round(state.massWater / MASS_ICE_INIT * PARTICLE_COUNT);
+    const gasCount = Math.max(0, PARTICLE_COUNT - solidCount - waterCount);
+    const meltCount = PARTICLE_COUNT - solidCount;
 
-    let solidCount = Math.round(state.massIce/MASS_ICE_INIT*PARTICLE_COUNT);
-    solidCount = Math.max(0, Math.min(solidCount, PARTICLE_COUNT));
-    let waterCount = Math.round(state.massWater/MASS_ICE_INIT*PARTICLE_COUNT);
-    waterCount = Math.max(0, Math.min(waterCount, PARTICLE_COUNT - solidCount));
-    const gasCount = PARTICLE_COUNT - solidCount - waterCount;
-    const meltCount = gasCount + waterCount;
+    const solidRows = Math.max(1, Math.ceil(solidCount / ICE_COLS));
+    const cSpacing = (iceWidth - 2 * PARTICLE_RADIUS) / (ICE_COLS - 1);
+    const rSpacing = solidRows > 1 ? (iceHeight - 2 * PARTICLE_RADIUS) / (solidRows - 1) : 0;
+
+    // numbers above already computed using mass ratios
 
     for(let i=0;i<PARTICLE_COUNT;i++){
         const p = particles[i];
-        if(i >= meltCount){
-            // solid lattice (top portion)
-            p.phase='solid';
-            const vibAmp=Math.max(0,Math.min(2,(state.temperature+10)*0.2));
-            const j=i-meltCount;
-            const row=Math.floor(j/ICE_COLS);
-            const col=j%ICE_COLS;
-            p.baseX = iceLeft + PARTICLE_RADIUS + col*cSpacing + (row%2?cSpacing/2:0);
-            p.baseY = iceBottom - PARTICLE_RADIUS - row*rSpacing;
-            p.x=p.baseX+vibAmp*Math.sin(Date.now()/200+p.baseX);
-            p.y=p.baseY+vibAmp*Math.sin(Date.now()/200+p.baseY);
+        if (i >= meltCount) {
+            // solid lattice top-aligned
+            p.phase = 'solid';
+            const vibAmp = Math.max(0, Math.min(2, (state.temperature + 10) * 0.2));
+            const j = i - meltCount;
+            const rowBottom = Math.floor(j / ICE_COLS);
+            const col = j % ICE_COLS;
+            const rowTop = solidRows - 1 - rowBottom;
+            p.baseX = iceLeft + PARTICLE_RADIUS + col * cSpacing + (rowTop % 2 ? cSpacing / 2 : 0);
+            p.baseY = iceTop + PARTICLE_RADIUS + rowTop * rSpacing;
+            p.x = p.baseX + vibAmp * Math.sin(Date.now() / 200 + p.baseX);
+            p.y = p.baseY + vibAmp * Math.sin(Date.now() / 200 + p.baseY);
         }else if(i >= gasCount){
             if(p.phase!=='liquid'){
                 p.x=beakerLeft+Math.random()*beakerWidth;

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -144,6 +144,8 @@ let graphData = [];
 let graphOffset = 0;
 let lastTime = 0;
 let frameCount = 0;
+let latticeTimer = 0;
+let lastSolidCount = ICE_COLS * ICE_ROWS;
 let beakerWidth, beakerLeft, pxPerM, beakerBottom;
 
 function resetState() {
@@ -164,6 +166,7 @@ function resetState() {
     graphOffset = 0;
     frameCount = 0;
     createParticles();
+    repositionSolidParticles();
     tempDisplay.textContent = `Temperature: ${state.temperature.toFixed(1)} °C`;
 }
 
@@ -182,6 +185,7 @@ function resize() {
     ICE_HEIGHT0 = (V0/(w0m*w0m))*pxPerM;
     C_SPACING0 = (ICE_WIDTH0 - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
     R_SPACING0 = (ICE_HEIGHT0 - 2*PARTICLE_RADIUS)/(ICE_ROWS - 1);
+    if(particles.length) repositionSolidParticles();
 }
 
 function createParticles() {
@@ -199,6 +203,34 @@ function createParticles() {
             particles.push({ row: r, col: c, x, y, vx: 0, vy: 0, phase: 'solid' });
         }
     }
+}
+
+function repositionSolidParticles(){
+    const solids = particles.filter(p=>p.phase==='solid');
+    const solidCount = solids.length;
+    const scale = getIceScale();
+    const iceWidth = ICE_WIDTH0 * scale;
+    const iceHeight = ICE_HEIGHT0 * scale;
+    const iceLeft = (canvas.width - iceWidth)/2;
+    const iceTop = getIceTopPx();
+    const rows = Math.max(1, Math.ceil(solidCount/ICE_COLS));
+    const cSpacing = (iceWidth - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
+    const rSpacing = rows>1 ? (iceHeight - 2*PARTICLE_RADIUS)/(rows - 1) : 0;
+    solids.forEach((p,i)=>{
+        const rowBottom = Math.floor(i/ICE_COLS);
+        const col = i % ICE_COLS;
+        const rowTop = rows-1-rowBottom;
+        p.baseX = iceLeft + PARTICLE_RADIUS + col*cSpacing + (rowTop%2?cSpacing/2:0);
+        p.baseY = iceTop + PARTICLE_RADIUS + rowTop*rSpacing;
+        p.x = p.baseX;
+        p.y = p.baseY;
+    });
+    lastSolidCount = solidCount;
+    latticeTimer = 0;
+}
+
+function countSolids(){
+    return particles.reduce((n,p)=>n+(p.phase==='solid'),0);
 }
 
 function getIceScale(){
@@ -277,120 +309,79 @@ function updatePhysics(dt){
 
 function updateParticles(dt){
     frameCount++;
-    const impulse = (frameCount % 10 === 0);
-    const scale = getIceScale();
-    const waterHeight = getWaterHeightPx();
-    const iceHeight = ICE_HEIGHT0 * scale;
-    const iceWidth = ICE_WIDTH0 * scale;
-    const iceLeft = (canvas.width - iceWidth)/2;
-    const iceTop = getIceTopPx();
-    const iceBottom = iceTop + iceHeight;
-    const solidCount = Math.round(state.massIce / MASS_ICE_INIT * PARTICLE_COUNT);
-    const waterCount = Math.round(state.massWater / MASS_ICE_INIT * PARTICLE_COUNT);
-    const gasCount = Math.max(0, PARTICLE_COUNT - solidCount - waterCount);
-    const meltCount = PARTICLE_COUNT - solidCount;
+    const impulse=(frameCount%10===0);
+    latticeTimer+=dt;
+    const waterHeight=getWaterHeightPx();
 
-    const solidRows = Math.max(1, Math.ceil(solidCount / ICE_COLS));
-    const cSpacing = (iceWidth - 2 * PARTICLE_RADIUS) / (ICE_COLS - 1);
-    const rSpacing = solidRows > 1 ? (iceHeight - 2 * PARTICLE_RADIUS) / (solidRows - 1) : 0;
-
-    // numbers above already computed using mass ratios
-
-    for(let i=0;i<PARTICLE_COUNT;i++){
-        const p = particles[i];
-        if (i >= meltCount) {
-            // solid lattice top-aligned
-            p.phase = 'solid';
-            const vibAmp = Math.max(0, Math.min(2, (state.temperature + 10) * 0.2));
-            const j = i - meltCount;
-            const rowBottom = Math.floor(j / ICE_COLS);
-            const col = j % ICE_COLS;
-            const rowTop = solidRows - 1 - rowBottom;
-            p.baseX = iceLeft + PARTICLE_RADIUS + col * cSpacing + (rowTop % 2 ? cSpacing / 2 : 0);
-            p.baseY = iceTop + PARTICLE_RADIUS + rowTop * rSpacing;
-            p.x = p.baseX + vibAmp * Math.sin(Date.now() / 200 + p.baseX);
-            p.y = p.baseY + vibAmp * Math.sin(Date.now() / 200 + p.baseY);
-        }else if(i >= gasCount){
-            if(p.phase!=='liquid'){
-                p.x=beakerLeft+Math.random()*beakerWidth;
-                p.y=beakerBottom-waterHeight*Math.random();
-                // higher base speed for liquid particles
-                p.vx=60*(Math.random()-0.5);
-                p.vy=60*(Math.random()-0.5);
-            }
+    const desiredSolid=Math.round(state.massIce/MASS_ICE_INIT*PARTICLE_COUNT);
+    let solids=particles.filter(p=>p.phase==='solid');
+    let currentSolid=solids.length;
+    if(currentSolid>desiredSolid){
+        solids.sort((a,b)=>b.baseY-a.baseY);
+        const melt=solids.slice(0,currentSolid-desiredSolid);
+        melt.forEach(p=>{
             p.phase='liquid';
+            p.x=beakerLeft+Math.random()*beakerWidth;
+            p.y=beakerBottom-waterHeight*Math.random();
+            p.vx=60*(Math.random()-0.5);
+            p.vy=60*(Math.random()-0.5);
+        });
+        currentSolid=desiredSolid;
+        solids=particles.filter(p=>p.phase==='solid');
+    }
+    if(latticeTimer>=0.5 || currentSolid!==lastSolidCount){
+        repositionSolidParticles();
+        solids=particles.filter(p=>p.phase==='solid');
+    }
+
+    solids.forEach(p=>{
+        const vibAmp=Math.max(0,Math.min(2,(state.temperature+10)*0.2));
+        p.x=p.baseX+vibAmp*Math.sin(Date.now()/200+p.baseX);
+        p.y=p.baseY+vibAmp*Math.sin(Date.now()/200+p.baseY);
+    });
+
+    particles.forEach(p=>{
+        if(p.phase==='liquid'){
             const tempFactor=Math.max(1,(state.temperature)/50+1);
-            // Brownian-like random impulses
-            p.vx += (Math.random() - 0.5) * BROWNIAN_LIQ * dt;
-            p.vy += (Math.random() - 0.5) * BROWNIAN_LIQ * dt;
+            p.vx+=(Math.random()-0.5)*BROWNIAN_LIQ*dt;
+            p.vy+=(Math.random()-0.5)*BROWNIAN_LIQ*dt;
             if(impulse){
-                p.vx += (Math.random() - 0.5) * BROWNIAN_LIQ_IMPULSE;
-                p.vy += (Math.random() - 0.5) * BROWNIAN_LIQ_IMPULSE;
+                p.vx+=(Math.random()-0.5)*BROWNIAN_LIQ_IMPULSE;
+                p.vy+=(Math.random()-0.5)*BROWNIAN_LIQ_IMPULSE;
             }
-            p.x += p.vx * dt * tempFactor;
-            p.y += p.vy * dt * tempFactor;
-            if(p.x < beakerLeft + PARTICLE_RADIUS){
-                p.x = beakerLeft + PARTICLE_RADIUS;
-                p.vx = Math.abs(p.vx);
-            }
-            if(p.x > beakerLeft + beakerWidth - PARTICLE_RADIUS){
-                p.x = beakerLeft + beakerWidth - PARTICLE_RADIUS;
-                p.vx = -Math.abs(p.vx);
-            }
-            if(p.y > beakerBottom - PARTICLE_RADIUS){
-                p.y = beakerBottom - PARTICLE_RADIUS;
-                p.vy = -Math.abs(p.vy);
-            }
-            const top = beakerBottom - waterHeight + PARTICLE_RADIUS;
-            if(p.y < top){
-                p.y = top;
-                p.vy = Math.abs(p.vy);
-            }
+            p.x+=p.vx*dt*tempFactor;
+            p.y+=p.vy*dt*tempFactor;
+            if(p.x<beakerLeft+PARTICLE_RADIUS){p.x=beakerLeft+PARTICLE_RADIUS;p.vx=Math.abs(p.vx);} 
+            if(p.x>beakerLeft+beakerWidth-PARTICLE_RADIUS){p.x=beakerLeft+beakerWidth-PARTICLE_RADIUS;p.vx=-Math.abs(p.vx);} 
+            if(p.y>beakerBottom-PARTICLE_RADIUS){p.y=beakerBottom-PARTICLE_RADIUS;p.vy=-Math.abs(p.vy);} 
+            const top=beakerBottom-waterHeight+PARTICLE_RADIUS;
+            if(p.y<top){p.y=top;p.vy=Math.abs(p.vy);} 
             let evapChance=0.02*Math.exp(state.temperature/50)*dt;
-            if(state.temperature>=100) evapChance*=2; // faster release when boiling
+            if(state.temperature>=100) evapChance*=2;
             if(p.y<beakerBottom-waterHeight+2*PARTICLE_RADIUS && Math.random()<evapChance){
                 p.phase='gas';
-                // give escaping particles uniform high speed
                 p.vx=GAS_VX*(Math.random()-0.5);
                 p.vy=-GAS_VY*Math.random();
-                const dm = MASS_ICE_INIT/PARTICLE_COUNT;
+                const dm=MASS_ICE_INIT/PARTICLE_COUNT;
                 state.massWater=Math.max(0,state.massWater-dm);
                 state.massSteam+=dm;
             }
-        }else{
-            if(p.phase!=='gas'){
-                p.x=beakerLeft+Math.random()*beakerWidth;
-                p.y=iceTop-Math.random()*100;
-                // initial gas particle speed (uniform)
-                p.vx=GAS_VX*(Math.random()-0.5);
-                p.vy=-GAS_VY*Math.random();
-            }
-            p.phase='gas';
-            // more intense Brownian motion in gas phase
-            p.vx += (Math.random() - 0.5) * BROWNIAN_GAS * dt;
-            p.vy += (Math.random() - 0.5) * BROWNIAN_GAS * dt;
+        }else if(p.phase==='gas'){
+            p.vx+=(Math.random()-0.5)*BROWNIAN_GAS*dt;
+            p.vy+=(Math.random()-0.5)*BROWNIAN_GAS*dt;
             if(impulse){
-                p.vx += (Math.random() - 0.5) * BROWNIAN_GAS_IMPULSE;
-                p.vy += (Math.random() - 0.5) * BROWNIAN_GAS_IMPULSE;
+                p.vx+=(Math.random()-0.5)*BROWNIAN_GAS_IMPULSE;
+                p.vy+=(Math.random()-0.5)*BROWNIAN_GAS_IMPULSE;
             }
-            p.x += p.vx * dt;
-            p.y += p.vy * dt;
-            if(p.x < beakerLeft + PARTICLE_RADIUS){
-                p.x = beakerLeft + PARTICLE_RADIUS;
-                p.vx = Math.abs(p.vx);
-            }
-            if(p.x > beakerLeft + beakerWidth - PARTICLE_RADIUS){
-                p.x = beakerLeft + beakerWidth - PARTICLE_RADIUS;
-                p.vx = -Math.abs(p.vx);
-            }
-            if(p.y > beakerBottom - PARTICLE_RADIUS){
-                p.y = beakerBottom - PARTICLE_RADIUS;
-                p.vy = -Math.abs(p.vy);
-            }
-            if(p.y < 0){p.y=-1000;} // disappear
+            p.x+=p.vx*dt;
+            p.y+=p.vy*dt;
+            if(p.x<beakerLeft+PARTICLE_RADIUS){p.x=beakerLeft+PARTICLE_RADIUS;p.vx=Math.abs(p.vx);} 
+            if(p.x>beakerLeft+beakerWidth-PARTICLE_RADIUS){p.x=beakerLeft+beakerWidth-PARTICLE_RADIUS;p.vx=-Math.abs(p.vx);} 
+            if(p.y>beakerBottom-PARTICLE_RADIUS){p.y=beakerBottom-PARTICLE_RADIUS;p.vy=-Math.abs(p.vy);} 
+            if(p.y<0){p.y=-1000;}
         }
-    }
-    // simple pairwise collisions for gas particles
+    });
+
     for(let i=0;i<PARTICLE_COUNT;i++){
         const a=particles[i];
         if(a.phase!=='gas' || a.y<-50) continue;
@@ -406,19 +397,13 @@ function updateParticles(dt){
                 const ny=dy/dist;
                 const dvx=b.vx-a.vx;
                 const dvy=b.vy-a.vy;
-                const rel=dx*dvx/dist + dy*dvy/dist;
+                const rel=dx*dvx/dist+dy*dvy/dist;
                 if(rel<0){
-                    const impulse=-rel*0.5;
-                    a.vx-=impulse*nx;
-                    a.vy-=impulse*ny;
-                    b.vx+=impulse*nx;
-                    b.vy+=impulse*ny;
+                    const imp=-rel*0.5;
+                    a.vx-=imp*nx; a.vy-=imp*ny; b.vx+=imp*nx; b.vy+=imp*ny;
                 }
                 const overlap=minDist-dist;
-                a.x-=nx*overlap/2;
-                a.y-=ny*overlap/2;
-                b.x+=nx*overlap/2;
-                b.y+=ny*overlap/2;
+                a.x-=nx*overlap/2; a.y-=ny*overlap/2; b.x+=nx*overlap/2; b.y+=ny*overlap/2;
             }
         }
     }

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -115,6 +115,10 @@ const GRAPH_X_SCALE = 6; // px per simulated second
 const FLAME_HEIGHT = 30; // px space for burner flame
 const GAS_VX = 1500; // px/s horizontal launch speed
 const GAS_VY = 1200; // px/s vertical launch speed
+const BROWNIAN_LIQ = 30;  // px/s^2 baseline jitter
+const BROWNIAN_GAS = 80;  // px/s^2 baseline jitter
+const BROWNIAN_LIQ_IMPULSE = 300; // px/s random kick every 10 frames
+const BROWNIAN_GAS_IMPULSE = 600; // px/s random kick every 10 frames
 
 let canvas = document.getElementById('mainCanvas');
 let gCanvas = document.getElementById('graphCanvas');
@@ -132,6 +136,7 @@ let particles = [];
 let graphData = [];
 let graphOffset = 0;
 let lastTime = 0;
+let frameCount = 0;
 let beakerWidth, beakerLeft, pxPerM, beakerBottom;
 
 function resetState() {
@@ -150,6 +155,7 @@ function resetState() {
     particles = [];
     graphData = [];
     graphOffset = 0;
+    frameCount = 0;
     createParticles();
     tempDisplay.textContent = `Temperature: ${state.temperature.toFixed(1)} °C`;
 }
@@ -244,6 +250,8 @@ function updatePhysics(dt){
 }
 
 function updateParticles(dt){
+    frameCount++;
+    const impulse = (frameCount % 10 === 0);
     const waterHeight = getWaterHeightPx();
     const iceHeight = getIceHeightPx();
     let solidCount = Math.round(state.massIce/0.2*PARTICLE_COUNT);
@@ -267,8 +275,12 @@ function updateParticles(dt){
             p.phase='liquid';
             const tempFactor=Math.max(1,(state.temperature)/50+1);
             // Brownian-like random impulses
-            p.vx+= (Math.random()-0.5)*30*dt;
-            p.vy+= (Math.random()-0.5)*30*dt;
+            p.vx += (Math.random() - 0.5) * BROWNIAN_LIQ * dt;
+            p.vy += (Math.random() - 0.5) * BROWNIAN_LIQ * dt;
+            if(impulse){
+                p.vx += (Math.random() - 0.5) * BROWNIAN_LIQ_IMPULSE;
+                p.vy += (Math.random() - 0.5) * BROWNIAN_LIQ_IMPULSE;
+            }
             p.x+=p.vx*dt*tempFactor;
             p.y+=p.vy*dt*tempFactor;
             if(p.x<beakerLeft+PARTICLE_RADIUS||p.x>beakerLeft+beakerWidth-PARTICLE_RADIUS)p.vx*=-1;
@@ -294,8 +306,12 @@ function updateParticles(dt){
             }
             p.phase='gas';
             // more intense Brownian motion in gas phase
-            p.vx+= (Math.random()-0.5)*80*dt;
-            p.vy+= (Math.random()-0.5)*80*dt;
+            p.vx += (Math.random() - 0.5) * BROWNIAN_GAS * dt;
+            p.vy += (Math.random() - 0.5) * BROWNIAN_GAS * dt;
+            if(impulse){
+                p.vx += (Math.random() - 0.5) * BROWNIAN_GAS_IMPULSE;
+                p.vy += (Math.random() - 0.5) * BROWNIAN_GAS_IMPULSE;
+            }
             p.x+=p.vx*dt;
             p.y+=p.vy*dt;
             if(p.x<beakerLeft+PARTICLE_RADIUS||p.x>beakerLeft+beakerWidth-PARTICLE_RADIUS)p.vx*=-1;

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -121,7 +121,7 @@ const BROWNIAN_LIQ_IMPULSE = 300; // px/s random kick every 10 frames
 const BROWNIAN_GAS_IMPULSE = 600; // px/s random kick every 10 frames
 const MASS_ICE_INIT = 0.2; // initial kg of ice
 const ICE_COLS = 20;
-const ICE_ROWS = 20;
+const ICE_ROWS = 20; // row 0 at bottom
 let ICE_WIDTH0 = 0;  // px, set during resize
 let ICE_HEIGHT0 = 0; // px, set during resize
 
@@ -185,13 +185,13 @@ function createParticles() {
     const iceWidth = getIceWidthPx();
     const iceHeight = getIceHeightPx();
     const startX = (canvas.width - iceWidth)/2;
-    const topY = getIceTopPx();
-    const spacingX = iceWidth/ICE_COLS;
-    const spacingY = iceHeight/ICE_ROWS;
+    const bottomY = getIceTopPx() + iceHeight;
+    const cSpacing = (iceWidth - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
+    const rSpacing = (iceHeight - 2*PARTICLE_RADIUS)/(ICE_ROWS - 1);
     for(let r=0;r<ICE_ROWS;r++){
         for(let c=0;c<ICE_COLS;c++){
-            const x = startX + c*spacingX + (r%2?spacingX/2:0);
-            const y = topY + r*spacingY;
+            const x = startX + PARTICLE_RADIUS + c*cSpacing + (r%2?cSpacing/2:0);
+            const y = bottomY - PARTICLE_RADIUS - r*rSpacing;
             particles.push({row:r,col:c,x,y,vx:0,vy:0,phase:'solid'});
         }
     }
@@ -280,8 +280,9 @@ function updateParticles(dt){
     const iceLeft = (canvas.width - iceWidth)/2;
     const iceTop = getIceTopPx();
     const startX = iceLeft;
-    const spacingX = iceWidth/ICE_COLS;
-    const spacingY = iceHeight/ICE_ROWS;
+    const iceBottom = iceTop + iceHeight;
+    const cSpacing = (iceWidth - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
+    const rSpacing = (iceHeight - 2*PARTICLE_RADIUS)/(ICE_ROWS - 1);
     let solidCount = Math.round(state.massIce/MASS_ICE_INIT*PARTICLE_COUNT);
     solidCount = Math.min(solidCount, PARTICLE_COUNT);
     let waterCount = Math.round(state.massWater/MASS_ICE_INIT*PARTICLE_COUNT);
@@ -290,8 +291,8 @@ function updateParticles(dt){
         if(i<solidCount){
             p.phase='solid';
             const vibAmp=Math.max(0,Math.min(2,(state.temperature+10)*0.2));
-            p.baseX = startX + p.col*spacingX + (p.row%2?spacingX/2:0);
-            p.baseY = iceTop + p.row*spacingY;
+            p.baseX = startX + PARTICLE_RADIUS + p.col*cSpacing + (p.row%2?cSpacing/2:0);
+            p.baseY = iceBottom - PARTICLE_RADIUS - p.row*rSpacing;
             p.x=p.baseX+vibAmp*Math.sin(Date.now()/200+p.baseX);
             p.y=p.baseY+vibAmp*Math.sin(Date.now()/200+p.baseY);
         }else if(i<solidCount+waterCount){

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -1,0 +1,443 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ice to Water to Steam Simulation</title>
+    <style>
+        body {
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            background-color: #f0f0f0;
+        }
+        h1 { margin-top: 20px; color: #2c3e50; }
+        .container {
+            display: flex;
+            gap: 20px;
+            width: 100%;
+            max-width: 1200px;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+        .canvas-stack {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        #mainCanvas {
+            border: 1px solid #2c3e50;
+            background-color: #fff;
+        }
+        #graphCanvas {
+            border: 1px solid #2c3e50;
+            background-color: #fff;
+            margin-top: 10px;
+        }
+        #graphLabel {
+            text-align: center;
+            font-size: 14px;
+            margin-top: 4px;
+        }
+        .controls {
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+            padding: 20px;
+            background-color: #ecf0f1;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            width: 300px;
+        }
+        .control-group {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .control-group button {
+            padding: 8px 12px;
+            background-color: #3498db;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .speed-buttons button { width: 60px; }
+        .main-buttons button { width: 100%; }
+    </style>
+</head>
+<body>
+    <h1>Ice → Water → Steam</h1>
+    <div class="container">
+        <div class="canvas-stack">
+            <canvas id="mainCanvas"></canvas>
+            <canvas id="graphCanvas" height="150"></canvas>
+            <div id="graphLabel">Temperature of ice/water (°C)</div>
+        </div>
+        <div class="controls">
+            <div class="control-group">
+                <label for="heatSlider">Burner Power (W)</label>
+                <input type="range" id="heatSlider" min="0" max="3000" value="200">
+                <span id="heatValue">200 W</span>
+            </div>
+            <div class="control-group speed-buttons">
+                <span>Time Rate</span>
+                <div>
+                    <button data-speed="1">×1</button>
+                    <button data-speed="2">×2</button>
+                    <button data-speed="3">×3</button>
+                </div>
+            </div>
+            <div class="control-group">
+                <span id="tempDisplay">Temperature: -10 °C</span>
+            </div>
+            <div class="control-group main-buttons">
+                <button id="startPause">Start</button>
+                <button id="reset">Reset</button>
+            </div>
+        </div>
+    </div>
+
+<script>
+const RHO_ICE = 917;   // kg/m^3
+const RHO_WATER = 1000;
+const C_ICE = 2100;    // J/(kg*K)
+const C_WATER = 4184;
+const L_FUS = 334000;  // J/kg
+const L_VAP = 2260000; // J/kg
+const PARTICLE_COUNT = 400;
+const PARTICLE_RADIUS = 3; // px
+const BEAKER_RADIUS_M = 0.05; // m, physical radius
+const BEAKER_AREA = Math.PI * BEAKER_RADIUS_M * BEAKER_RADIUS_M;
+const GRAPH_X_SCALE = 6; // px per simulated second
+const FLAME_HEIGHT = 30; // px space for burner flame
+const GAS_VX = 1500; // px/s horizontal launch speed
+const GAS_VY = 1200; // px/s vertical launch speed
+
+let canvas = document.getElementById('mainCanvas');
+let gCanvas = document.getElementById('graphCanvas');
+let ctx = canvas.getContext('2d');
+let gctx = gCanvas.getContext('2d');
+let heatSlider = document.getElementById('heatSlider');
+let heatValue = document.getElementById('heatValue');
+let tempDisplay = document.getElementById('tempDisplay');
+let startPauseBtn = document.getElementById('startPause');
+let resetBtn = document.getElementById('reset');
+let speedButtons = document.querySelectorAll('[data-speed]');
+
+let state;
+let particles = [];
+let graphData = [];
+let graphOffset = 0;
+let lastTime = 0;
+let beakerWidth, beakerLeft, pxPerM, beakerBottom;
+
+function resetState() {
+    state = {
+        massIce: 0.2,     // kg
+        massWater: 0,
+        massSteam: 0,
+        temperature: -10, // Celsius
+        energy: 0,
+        running: false,
+        speed: 1,
+        power: +heatSlider.value,
+        phase: 'solid',
+        time: 0
+    };
+    particles = [];
+    graphData = [];
+    graphOffset = 0;
+    createParticles();
+    tempDisplay.textContent = `Temperature: ${state.temperature.toFixed(1)} °C`;
+}
+
+function resize() {
+    const width = Math.min(600, window.innerWidth*0.6);
+    canvas.width = width;
+    canvas.height = width*1.2;
+    gCanvas.width = width;
+    beakerWidth = width*0.6;
+    beakerLeft = (width-beakerWidth)/2;
+    pxPerM = beakerWidth/(BEAKER_RADIUS_M*2);
+    beakerBottom = canvas.height - FLAME_HEIGHT;
+}
+
+function createParticles() {
+    particles = [];
+    const cols = 20;
+    const rows = 20;
+    const iceHeight = getIceHeightPx();
+    const iceWidth = beakerWidth*2/3;
+    const startX = (canvas.width-iceWidth)/2;
+    const startY = beakerBottom-iceHeight;
+    const spacingX = iceWidth/cols;
+    const spacingY = iceHeight/rows;
+    for(let r=0;r<rows;r++){
+        for(let c=0;c<cols;c++){
+            let x = startX + c*spacingX + (r%2?spacingX/2:0);
+            let y = startY + r*spacingY;
+            particles.push({x,y,vx:0,vy:0,phase:'solid',baseX:x,baseY:y});
+        }
+    }
+}
+
+function getIceHeightPx(){
+    const V = state.massIce / RHO_ICE; // m^3
+    const h = V / BEAKER_AREA; // m
+    return h * pxPerM;
+}
+function getWaterHeightPx(){
+    const V = state.massWater / RHO_WATER;
+    const h = V / BEAKER_AREA;
+    return h * pxPerM;
+}
+
+function updatePhysics(dt){
+    state.energy += state.power * dt;
+    switch(state.phase){
+        case 'solid':
+            if(state.temperature < 0){
+                const needed = state.massIce*C_ICE*(0-state.temperature);
+                if(state.energy >= needed){
+                    state.energy -= needed;
+                    state.temperature = 0;
+                }else{
+                    state.temperature += state.energy/(state.massIce*C_ICE);
+                    state.energy = 0;
+                }
+            }else{
+                // melting
+                const meltNeeded = state.massIce*L_FUS;
+                const dm = Math.min(state.energy/L_FUS,state.massIce);
+                state.massIce -= dm;
+                state.massWater += dm;
+                state.energy -= dm*L_FUS;
+                if(state.massIce===0){state.phase='liquid';}
+            }
+            break;
+        case 'liquid':
+            if(state.temperature < 100){
+                const needed = state.massWater*C_WATER*(100-state.temperature);
+                if(state.energy >= needed){
+                    state.energy -= needed;
+                    state.temperature = 100;
+                }else{
+                    state.temperature += state.energy/(state.massWater*C_WATER);
+                    state.energy = 0;
+                }
+            }else{
+                const dm = Math.min(state.energy/L_VAP,state.massWater);
+                state.massWater -= dm;
+                state.massSteam += dm;
+                state.energy -= dm*L_VAP;
+                if(state.massWater===0){state.phase='gas';}
+            }
+            break;
+        case 'gas':
+            state.temperature += state.energy/(state.massSteam*C_WATER);
+            state.energy = 0;
+            break;
+    }
+}
+
+function updateParticles(dt){
+    const waterHeight = getWaterHeightPx();
+    const iceHeight = getIceHeightPx();
+    let solidCount = Math.round(state.massIce/0.2*PARTICLE_COUNT);
+    solidCount = Math.min(solidCount, PARTICLE_COUNT);
+    let waterCount = Math.round(state.massWater/0.2*PARTICLE_COUNT);
+    for(let i=0;i<PARTICLE_COUNT;i++){
+        const p = particles[i];
+        if(i<solidCount){
+            p.phase='solid';
+            const vibAmp=Math.max(0,Math.min(2,(state.temperature+10)*0.2));
+            p.x=p.baseX+vibAmp*Math.sin(Date.now()/200+p.baseX);
+            p.y=p.baseY+vibAmp*Math.sin(Date.now()/200+p.baseY);
+        }else if(i<solidCount+waterCount){
+            if(p.phase!=='liquid'){
+                p.x=beakerLeft+Math.random()*beakerWidth;
+                p.y=beakerBottom-waterHeight*Math.random();
+                // higher base speed for liquid particles
+                p.vx=60*(Math.random()-0.5);
+                p.vy=60*(Math.random()-0.5);
+            }
+            p.phase='liquid';
+            const tempFactor=Math.max(1,(state.temperature)/50+1);
+            // Brownian-like random impulses
+            p.vx+= (Math.random()-0.5)*30*dt;
+            p.vy+= (Math.random()-0.5)*30*dt;
+            p.x+=p.vx*dt*tempFactor;
+            p.y+=p.vy*dt*tempFactor;
+            if(p.x<beakerLeft+PARTICLE_RADIUS||p.x>beakerLeft+beakerWidth-PARTICLE_RADIUS)p.vx*=-1;
+            if(p.y>beakerBottom-PARTICLE_RADIUS){p.vy*=-1;p.y=beakerBottom-PARTICLE_RADIUS;}
+            if(p.y<beakerBottom-waterHeight+PARTICLE_RADIUS){p.vy*=-1;p.y=beakerBottom-waterHeight+PARTICLE_RADIUS;}
+            let evapChance=0.02*Math.exp(state.temperature/50)*dt;
+            if(state.temperature>=100) evapChance*=2; // faster release when boiling
+            if(p.y<beakerBottom-waterHeight+2*PARTICLE_RADIUS && Math.random()<evapChance){
+                p.phase='gas';
+                // give escaping particles uniform high speed
+                p.vx=GAS_VX*(Math.random()-0.5);
+                p.vy=-GAS_VY*Math.random();
+                state.massWater=Math.max(0,state.massWater-0.2/PARTICLE_COUNT);
+                state.massSteam+=0.2/PARTICLE_COUNT;
+            }
+        }else{
+            if(p.phase!=='gas'){
+                p.x=beakerLeft+Math.random()*beakerWidth;
+                p.y=beakerBottom-waterHeight-iceHeight-Math.random()*100;
+                // initial gas particle speed (uniform)
+                p.vx=GAS_VX*(Math.random()-0.5);
+                p.vy=-GAS_VY*Math.random();
+            }
+            p.phase='gas';
+            // more intense Brownian motion in gas phase
+            p.vx+= (Math.random()-0.5)*80*dt;
+            p.vy+= (Math.random()-0.5)*80*dt;
+            p.x+=p.vx*dt;
+            p.y+=p.vy*dt;
+            if(p.x<beakerLeft+PARTICLE_RADIUS||p.x>beakerLeft+beakerWidth-PARTICLE_RADIUS)p.vx*=-1;
+            if(p.y<0){p.y=-1000;} // disappear
+        }
+    }
+    // simple pairwise collisions for gas particles
+    for(let i=0;i<PARTICLE_COUNT;i++){
+        const a=particles[i];
+        if(a.phase!=='gas' || a.y<-50) continue;
+        for(let j=i+1;j<PARTICLE_COUNT;j++){
+            const b=particles[j];
+            if(b.phase!=='gas' || b.y<-50) continue;
+            const dx=b.x-a.x;
+            const dy=b.y-a.y;
+            const dist=Math.hypot(dx,dy);
+            const minDist=PARTICLE_RADIUS*2;
+            if(dist>0 && dist<minDist){
+                const nx=dx/dist;
+                const ny=dy/dist;
+                const dvx=b.vx-a.vx;
+                const dvy=b.vy-a.vy;
+                const rel=dx*dvx/dist + dy*dvy/dist;
+                if(rel<0){
+                    const impulse=-rel*0.5;
+                    a.vx-=impulse*nx;
+                    a.vy-=impulse*ny;
+                    b.vx+=impulse*nx;
+                    b.vy+=impulse*ny;
+                }
+                const overlap=minDist-dist;
+                a.x-=nx*overlap/2;
+                a.y-=ny*overlap/2;
+                b.x+=nx*overlap/2;
+                b.y+=ny*overlap/2;
+            }
+        }
+    }
+}
+
+function draw(){
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    // beaker
+    ctx.strokeStyle='#555';
+    ctx.lineWidth=2;
+    ctx.strokeRect(beakerLeft,10,beakerWidth,beakerBottom-10);
+
+    // burner flame arrows
+    const arrowWidth = 5 + state.power/300;
+    const flameHeight = FLAME_HEIGHT - 5;
+    ctx.fillStyle = 'red';
+    for(let i=-1;i<=1;i++){
+        const x = beakerLeft + beakerWidth/2 + i*(arrowWidth+3) - arrowWidth/2;
+        ctx.beginPath();
+        ctx.moveTo(x, beakerBottom + flameHeight);
+        ctx.lineTo(x+arrowWidth/2, beakerBottom);
+        ctx.lineTo(x+arrowWidth, beakerBottom + flameHeight);
+        ctx.closePath();
+        ctx.fill();
+    }
+
+    const waterHeight = getWaterHeightPx();
+    const iceHeight = getIceHeightPx();
+
+    // water
+    if(state.massWater>0){
+        ctx.fillStyle='rgba(0,150,255,0.3)';
+        ctx.fillRect(beakerLeft,beakerBottom-waterHeight,beakerWidth,waterHeight);
+    }
+    // ice
+    if(state.massIce>0){
+        ctx.fillStyle='#c0c0c0';
+        ctx.fillRect(beakerLeft + beakerWidth/6,beakerBottom-waterHeight-iceHeight,beakerWidth*2/3,iceHeight);
+    }
+
+    // particles
+    ctx.fillStyle='#555';
+    particles.forEach(p=>{
+        if(p.phase!=='gas' || (p.y>-50)){
+            ctx.beginPath();
+            ctx.arc(p.x,p.y,PARTICLE_RADIUS,0,Math.PI*2);
+            ctx.fill();
+        }
+    });
+
+    // update graph
+    gctx.clearRect(0,0,gCanvas.width,gCanvas.height);
+    gctx.strokeStyle='#e74c3c';
+    gctx.beginPath();
+    const lastX = graphData.length ? graphData[graphData.length-1].time*GRAPH_X_SCALE : 0;
+    if(lastX - graphOffset > gCanvas.width) graphOffset = lastX - gCanvas.width;
+    graphData.forEach((pt,i)=>{
+        const x = pt.time*GRAPH_X_SCALE - graphOffset;
+        const y = gCanvas.height - (pt.temp+20);
+        if(i===0) gctx.moveTo(x,y); else gctx.lineTo(x,y);
+    });
+    gctx.stroke();
+}
+
+function loop(ts){
+    if(!lastTime) lastTime=ts;
+    const dt=(ts-lastTime)/1000*state.speed;
+    lastTime=ts;
+    if(state.running){
+        state.time=(state.time||0)+dt;
+        updatePhysics(dt);
+        updateParticles(dt);
+        if(state.massWater===0 && state.massIce===0){
+            state.running=false;
+            startPauseBtn.textContent='Start';
+        }
+        if(!graphData.length||state.time-graphData[graphData.length-1].time>0.5){
+            graphData.push({time:state.time,temp:state.temperature});
+        }
+        tempDisplay.textContent=`Temperature: ${state.temperature.toFixed(1)} °C`;
+    }
+    draw();
+    requestAnimationFrame(loop);
+}
+
+heatSlider.addEventListener('input',()=>{
+    state.power=+heatSlider.value;
+    heatValue.textContent=`${state.power} W`;
+});
+
+startPauseBtn.addEventListener('click',()=>{
+    state.running=!state.running;
+    startPauseBtn.textContent=state.running?'Pause':'Start';
+});
+resetBtn.addEventListener('click',()=>{
+    resetState();
+    startPauseBtn.textContent='Start';
+});
+
+speedButtons.forEach(btn=>btn.addEventListener('click',()=>{
+    state.speed=+btn.dataset.speed;
+}));
+
+window.addEventListener('resize',resize);
+resize();
+resetState();
+requestAnimationFrame(loop);
+</script>
+</body>
+</html>

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -119,6 +119,11 @@ const BROWNIAN_LIQ = 30;  // px/s^2 baseline jitter
 const BROWNIAN_GAS = 80;  // px/s^2 baseline jitter
 const BROWNIAN_LIQ_IMPULSE = 300; // px/s random kick every 10 frames
 const BROWNIAN_GAS_IMPULSE = 600; // px/s random kick every 10 frames
+const MASS_ICE_INIT = 0.2; // initial kg of ice
+const ICE_COLS = 20;
+const ICE_ROWS = 20;
+let ICE_WIDTH0 = 0;  // px, set during resize
+let ICE_HEIGHT0 = 0; // px, set during resize
 
 let canvas = document.getElementById('mainCanvas');
 let gCanvas = document.getElementById('graphCanvas');
@@ -141,7 +146,7 @@ let beakerWidth, beakerLeft, pxPerM, beakerBottom;
 
 function resetState() {
     state = {
-        massIce: 0.2,     // kg
+        massIce: MASS_ICE_INIT,     // kg
         massWater: 0,
         massSteam: 0,
         temperature: -10, // Celsius
@@ -169,31 +174,45 @@ function resize() {
     beakerLeft = (width-beakerWidth)/2;
     pxPerM = beakerWidth/(BEAKER_RADIUS_M*2);
     beakerBottom = canvas.height - FLAME_HEIGHT;
+    ICE_WIDTH0 = beakerWidth*2/3;
+    const w0m = ICE_WIDTH0/pxPerM;
+    const V0 = MASS_ICE_INIT / RHO_ICE;
+    ICE_HEIGHT0 = (V0/(w0m*w0m))*pxPerM;
 }
 
 function createParticles() {
     particles = [];
-    const cols = 20;
-    const rows = 20;
+    const iceWidth = getIceWidthPx();
     const iceHeight = getIceHeightPx();
-    const iceWidth = beakerWidth*2/3;
-    const startX = (canvas.width-iceWidth)/2;
-    const startY = beakerBottom-iceHeight;
-    const spacingX = iceWidth/cols;
-    const spacingY = iceHeight/rows;
-    for(let r=0;r<rows;r++){
-        for(let c=0;c<cols;c++){
-            let x = startX + c*spacingX + (r%2?spacingX/2:0);
-            let y = startY + r*spacingY;
-            particles.push({x,y,vx:0,vy:0,phase:'solid',baseX:x,baseY:y});
+    const startX = (canvas.width - iceWidth)/2;
+    const topY = getIceTopPx();
+    const spacingX = iceWidth/ICE_COLS;
+    const spacingY = iceHeight/ICE_ROWS;
+    for(let r=0;r<ICE_ROWS;r++){
+        for(let c=0;c<ICE_COLS;c++){
+            const x = startX + c*spacingX + (r%2?spacingX/2:0);
+            const y = topY + r*spacingY;
+            particles.push({row:r,col:c,x,y,vx:0,vy:0,phase:'solid'});
         }
     }
 }
 
+function getIceScale(){
+    return Math.cbrt(state.massIce / MASS_ICE_INIT);
+}
+function getIceWidthPx(){
+    return ICE_WIDTH0 * getIceScale();
+}
 function getIceHeightPx(){
-    const V = state.massIce / RHO_ICE; // m^3
-    const h = V / BEAKER_AREA; // m
-    return h * pxPerM;
+    return ICE_HEIGHT0 * getIceScale();
+}
+function getIceTopPx(){
+    const h = getIceHeightPx();
+    const waterHeight = getWaterHeightPx();
+    if(waterHeight > h*2/3){
+        return beakerBottom - waterHeight - h/3;
+    }
+    return beakerBottom - waterHeight - h;
 }
 function getWaterHeightPx(){
     const V = state.massWater / RHO_WATER;
@@ -254,14 +273,21 @@ function updateParticles(dt){
     const impulse = (frameCount % 10 === 0);
     const waterHeight = getWaterHeightPx();
     const iceHeight = getIceHeightPx();
-    let solidCount = Math.round(state.massIce/0.2*PARTICLE_COUNT);
+    const iceWidth = getIceWidthPx();
+    const iceTop = getIceTopPx();
+    const startX = (canvas.width - iceWidth)/2;
+    const spacingX = iceWidth/ICE_COLS;
+    const spacingY = iceHeight/ICE_ROWS;
+    let solidCount = Math.round(state.massIce/MASS_ICE_INIT*PARTICLE_COUNT);
     solidCount = Math.min(solidCount, PARTICLE_COUNT);
-    let waterCount = Math.round(state.massWater/0.2*PARTICLE_COUNT);
+    let waterCount = Math.round(state.massWater/MASS_ICE_INIT*PARTICLE_COUNT);
     for(let i=0;i<PARTICLE_COUNT;i++){
         const p = particles[i];
         if(i<solidCount){
             p.phase='solid';
             const vibAmp=Math.max(0,Math.min(2,(state.temperature+10)*0.2));
+            p.baseX = startX + p.col*spacingX + (p.row%2?spacingX/2:0);
+            p.baseY = iceTop + p.row*spacingY;
             p.x=p.baseX+vibAmp*Math.sin(Date.now()/200+p.baseX);
             p.y=p.baseY+vibAmp*Math.sin(Date.now()/200+p.baseY);
         }else if(i<solidCount+waterCount){
@@ -307,13 +333,14 @@ function updateParticles(dt){
                 // give escaping particles uniform high speed
                 p.vx=GAS_VX*(Math.random()-0.5);
                 p.vy=-GAS_VY*Math.random();
-                state.massWater=Math.max(0,state.massWater-0.2/PARTICLE_COUNT);
-                state.massSteam+=0.2/PARTICLE_COUNT;
+                const dm = MASS_ICE_INIT/PARTICLE_COUNT;
+                state.massWater=Math.max(0,state.massWater-dm);
+                state.massSteam+=dm;
             }
         }else{
             if(p.phase!=='gas'){
                 p.x=beakerLeft+Math.random()*beakerWidth;
-                p.y=beakerBottom-waterHeight-iceHeight-Math.random()*100;
+                p.y=iceTop-Math.random()*100;
                 // initial gas particle speed (uniform)
                 p.vx=GAS_VX*(Math.random()-0.5);
                 p.vy=-GAS_VY*Math.random();
@@ -409,7 +436,7 @@ function draw(){
     // ice
     if(state.massIce>0){
         ctx.fillStyle='#c0c0c0';
-        ctx.fillRect(beakerLeft + beakerWidth/6,beakerBottom-waterHeight-iceHeight,beakerWidth*2/3,iceHeight);
+        ctx.fillRect(iceLeft, iceTop, iceWidth, iceHeight);
     }
 
     // particles

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -274,8 +274,9 @@ function updateParticles(dt){
     const waterHeight = getWaterHeightPx();
     const iceHeight = getIceHeightPx();
     const iceWidth = getIceWidthPx();
+    const iceLeft = (canvas.width - iceWidth)/2;
     const iceTop = getIceTopPx();
-    const startX = (canvas.width - iceWidth)/2;
+    const startX = iceLeft;
     const spacingX = iceWidth/ICE_COLS;
     const spacingY = iceHeight/ICE_ROWS;
     let solidCount = Math.round(state.massIce/MASS_ICE_INIT*PARTICLE_COUNT);
@@ -427,6 +428,9 @@ function draw(){
 
     const waterHeight = getWaterHeightPx();
     const iceHeight = getIceHeightPx();
+    const iceWidth = getIceWidthPx();
+    const iceLeft = (canvas.width - iceWidth)/2;
+    const iceTop = getIceTopPx();
 
     // water
     if(state.massWater>0){

--- a/ice_water_steam.html
+++ b/ice_water_steam.html
@@ -119,9 +119,11 @@ const BROWNIAN_LIQ = 30;  // px/s^2 baseline jitter
 const BROWNIAN_GAS = 80;  // px/s^2 baseline jitter
 const BROWNIAN_LIQ_IMPULSE = 300; // px/s random kick every 10 frames
 const BROWNIAN_GAS_IMPULSE = 600; // px/s random kick every 10 frames
-const MASS_ICE_INIT = 0.2; // initial kg of ice
+const ICE_SIDE_M = 0.06; // 6 cm cube
+const ICE_VOLUME = ICE_SIDE_M ** 3; // m^3
+const MASS_ICE_INIT = RHO_ICE * ICE_VOLUME; // ~0.2 kg
 const ICE_COLS = 20;
-const ICE_ROWS = 20; // row 0 at bottom
+const ICE_ROWS = 20; // row 0 at top
 let ICE_WIDTH0 = 0;  // px, set during resize
 let ICE_HEIGHT0 = 0; // px, set during resize
 let C_SPACING0 = 0;  // base column spacing
@@ -179,10 +181,8 @@ function resize() {
     beakerLeft = (width-beakerWidth)/2;
     pxPerM = beakerWidth/(BEAKER_RADIUS_M*2);
     beakerBottom = canvas.height - FLAME_HEIGHT;
-    ICE_WIDTH0 = beakerWidth*2/3;
-    const w0m = ICE_WIDTH0/pxPerM;
-    const V0 = MASS_ICE_INIT / RHO_ICE;
-    ICE_HEIGHT0 = (V0/(w0m*w0m))*pxPerM;
+    ICE_WIDTH0 = ICE_SIDE_M * pxPerM;
+    ICE_HEIGHT0 = ICE_SIDE_M * pxPerM;
     C_SPACING0 = (ICE_WIDTH0 - 2*PARTICLE_RADIUS)/(ICE_COLS - 1);
     R_SPACING0 = (ICE_HEIGHT0 - 2*PARTICLE_RADIUS)/(ICE_ROWS - 1);
     if(particles.length) repositionSolidParticles();
@@ -198,7 +198,8 @@ function createParticles() {
     const rSpacing = (iceHeight - 2 * PARTICLE_RADIUS) / (ICE_ROWS - 1);
     for (let r = 0; r < ICE_ROWS; r++) {
         for (let c = 0; c < ICE_COLS; c++) {
-            const x = startX + PARTICLE_RADIUS + c * cSpacing + (r % 2 ? cSpacing / 2 : 0);
+            const offset = ((ICE_ROWS - 1 - r) % 2 ? cSpacing / 2 : 0);
+            const x = startX + PARTICLE_RADIUS + c * cSpacing + offset;
             const y = iceTop + PARTICLE_RADIUS + r * rSpacing;
             particles.push({ row: r, col: c, x, y, vx: 0, vy: 0, phase: 'solid' });
         }
@@ -220,7 +221,8 @@ function repositionSolidParticles(){
         const rowBottom = Math.floor(i/ICE_COLS);
         const col = i % ICE_COLS;
         const rowTop = rows-1-rowBottom;
-        p.baseX = iceLeft + PARTICLE_RADIUS + col*cSpacing + (rowTop%2?cSpacing/2:0);
+        const offset = ((ICE_ROWS - 1 - rowTop) % 2 ? cSpacing / 2 : 0);
+        p.baseX = iceLeft + PARTICLE_RADIUS + col*cSpacing + offset;
         p.baseY = iceTop + PARTICLE_RADIUS + rowTop*rSpacing;
         p.x = p.baseX;
         p.y = p.baseY;
@@ -317,7 +319,10 @@ function updateParticles(dt){
     let solids=particles.filter(p=>p.phase==='solid');
     let currentSolid=solids.length;
     if(currentSolid>desiredSolid){
-        solids.sort((a,b)=>b.baseY-a.baseY);
+        solids.sort((a,b)=>{
+            if(b.baseY!==a.baseY) return b.baseY-a.baseY;
+            return b.baseX-a.baseX;
+        });
         const melt=solids.slice(0,currentSolid-desiredSolid);
         melt.forEach(p=>{
             p.phase='liquid';

--- a/index.html
+++ b/index.html
@@ -124,6 +124,9 @@
         <a class="tile" href="turing_machine.html">
           <h2>Turing Machine</h2>
         </a>
+        <a class="tile" href="ice_water_steam.html">
+          <h2>Ice → Water → Steam</h2>
+        </a>
       </div>
     </main>
     <footer>&copy; 2025 Learning Demos</footer>


### PR DESCRIPTION
## Summary
- simulate Brownian motion for liquid and gas particles
- double evaporation rate when water reaches boiling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6857cd058b788322a02b0b9588f065e6